### PR TITLE
Update starter-plugin.php

### DIFF
--- a/starter-plugin.php
+++ b/starter-plugin.php
@@ -170,7 +170,7 @@ final class Starter_Plugin {
 	 */
 	private function _log_version_number () {
 		// Log the version number.
-		update_option( $this->_token . '-version', $this->version );
+		update_option( $this->token . '-version', $this->version );
 	} // End _log_version_number()
 } // End Class
 ?>


### PR DESCRIPTION
fixes `The plugin generated 231 characters of unexpected output during activation` notice.
