### PR TITLE
Allow multiple taxonomy registration

### DIFF
--- a/classes/class-starter-plugin-post-type.php
+++ b/classes/class-starter-plugin-post-type.php
@@ -171,7 +171,7 @@ class Starter_Plugin_Post_Type {
 	 * @access public
 	 * @param array $defaults
 	 * @since  1.0.0
-	 * @return void
+	 * @return array $defaults
 	 */
 	public function register_custom_column_headings ( $defaults ) {
 		$new_columns = array( 'image' => __( 'Image', 'starter-plugin' ) );

--- a/classes/class-starter-plugin-post-type.php
+++ b/classes/class-starter-plugin-post-type.php
@@ -139,8 +139,10 @@ class Starter_Plugin_Post_Type {
 	 * @return void
 	 */
 	public function register_taxonomy () {
-		$this->taxonomies['thing-category'] = new Starter_Plugin_Taxonomy(); // Leave arguments empty, to use the default arguments.
-		$this->taxonomies['thing-category']->register();
+		foreach ( $taxonomies as $taxonomy ) :
+			$taxonomy = new Starter_Plugin_Taxonomy( esc_attr( $this->post_type ), $taxonomy, '', '', array() ); // Leave arguments empty, to use the default arguments.
+			$taxonomy->register();
+		endforeach;
 	} // End register_taxonomy()
 
 	/**

--- a/classes/class-starter-plugin-taxonomy.php
+++ b/classes/class-starter-plugin-taxonomy.php
@@ -73,6 +73,8 @@ class Starter_Plugin_Taxonomy {
 		if ( '' == $this->plural ) $this->plural = __( 'Categories', 'starter-plugin' );
 
 		$this->args = wp_parse_args( $args, $this->_get_default_args() );
+		
+		add_action( 'init', array( $this, 'register' ) );
 	} // End __construct()
 
 	/**

--- a/starter-plugin.php
+++ b/starter-plugin.php
@@ -108,6 +108,17 @@ final class Starter_Plugin {
 	 */
 	public $post_types = array();
 	// Post Types - End
+	
+	// Taxonomies - Start
+	/**
+	 * The taxonomies we're registering.
+	 * @var     array
+	 * @access  public
+	 * @since   1.0.0
+	 */
+	public $taxonomies = array();
+	// Taxonomies - End
+	
 	/**
 	 * Constructor function.
 	 * @access  public
@@ -136,6 +147,10 @@ final class Starter_Plugin {
 		// Register an example post type. To register other post types, duplicate this line.
 		$this->post_types['thing'] = new Starter_Plugin_Post_Type( 'thing', __( 'Thing', 'starter-plugin' ), __( 'Things', 'starter-plugin' ), array( 'menu_icon' => 'dashicons-carrot' ) );
 		// Post Types - End
+		
+		//Register an example taxonomy. To register more taxonomies, duplicate this line.
+		$this->taxonomies['taxonomy'] = new Starter_Plugin_Taxonomy( 'thing', 'taxonomy_name', __( 'Taxonomy Name', 'starter-plugin' ), __( 'Taxonomy Names', 'starter-plugin' ) );
+		
 		register_activation_hook( __FILE__, array( $this, 'install' ) );
 
 		add_action( 'init', array( $this, 'load_plugin_textdomain' ) );


### PR DESCRIPTION
Right now, calling the taxonomy class directly is pointless as the register method is not hooked to init.

Also, since we allow multiple post types registration, we might as well allow multiple taxonomy registration.
